### PR TITLE
box-sizing: content-box rule

### DIFF
--- a/build/scss/radialtimer.scss
+++ b/build/scss/radialtimer.scss
@@ -56,6 +56,7 @@ $fontSize: 70px;
 			clip: rect(0px, ($sizeTimer / 2), $sizeTimer, 0px);
 			border-radius: 50%;
 			transition: all 1s linear;
+			box-sizing: content-box;
 			z-index: 1;
 		}
 	}

--- a/public_html/css/radialtimer.css
+++ b/public_html/css/radialtimer.css
@@ -50,5 +50,6 @@
   clip: rect(0px, 100px, 200px, 0px);
   border-radius: 50%;
   transition: all 1s linear;
+  box-sizing: content-box;
   z-index: 1;
 }


### PR DESCRIPTION
I am using a CSS framework which overrides the default box-sizing rule. This change is to enforce the box-sizing set to content-box. 
